### PR TITLE
Don't use master branch in README PR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,20 @@ This won't do anything in the beginning, but as we work through the exercises yo
 
 During the class (and for homework), we will go through each folder, reading the README and completing the exercises.
 
-For **homework**, we expect you to `add` and `commit` your changes, and `push` them to your own repo (`origin`). You will then need to open a `pull request` so we can review your code.
+For **homework**, we expect you to `add` and `commit` your changes on a new branch (not `master`), and `push` them to your own repo (`origin`). You will then need to open a `pull request` so we can review your code.
 
 ### Opening a pull request
 
-A pull request is a request to merge one branch into another. In this case you will request to have the `master` branch of your repo, merged into the `master` branch of this (`upstream`) repo.
+A pull request is a request to merge one branch into another. You will request to have a branch of your (`origin`) repo merged into the `master` branch of this (`upstream`) repo.
 
 We won't actually merge your branch, but the pull request will allow us to view and comment on your work.
 
+Assuming you have created a branch called `my-homework` (for example, using `git checkout -b my-homework`) to contain your work
+
 1. Add each individual file you have changed using `git add [path to file]`
 2. Commit your changes using `git commit` (you can add and commit changes multiple times as you complete exercises)
-3. Push your changes to your own repo using `git push origin [your branch name]`
-4. Go to https://github.com/rarmatei/js-exercises and click the **New pull request** button (this create a request to merge your `origin/master` to our `remote/master`)
-5. Give your pull request a title e.g. `Daniel's homework`
-6. Click **Create pull request**
+3. Push your changes to your own repo using `git push origin my-homework`
+4. Go to https://github.com/rarmatei/js-exercises and click the **New pull request** button
+5. This creates a request to merge your `master` to our `master`. You shouldn't have changes on your `master` branch, so select your branch (e.g.`my-homework`) on the right instead.
+6. Give your pull request a title e.g. `Daniel's homework`.
+7. Click **Create pull request**


### PR DESCRIPTION
The instructions on creating a PR for js-exercises tell the students
to make changes on the master branch. In practice we recommend that
they never work directly on master.

I've changed the instructions to use a separate branch called
"my-homework".